### PR TITLE
WSF-PHP: Support for php 5.4

### DIFF
--- a/php/src/wsf.c
+++ b/php/src/wsf.c
@@ -458,8 +458,12 @@ php_ws_object_new_ex(
 
     ALLOC_HASHTABLE(intern->std.properties);
     zend_hash_init(intern->std.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
-    zend_hash_copy(intern->std.properties, &class_type->default_properties,
-            (copy_ctor_func_t) zval_add_ref, (void *) & tmp, sizeof (void *));
+#if PHP_VERSION_ID < 50399
+        zend_hash_copy(intern->std.properties, &class_type->default_properties,
+                (copy_ctor_func_t) zval_add_ref, (void *) & tmp, sizeof (void *));
+#else
+        object_properties_init(&(intern->std), class_type); 
+#endif
 
     retval.handle = zend_objects_store_put(intern,
             (zend_objects_store_dtor_t) zend_objects_destroy_object,

--- a/php/src/wsf_util.c
+++ b/php/src/wsf_util.c
@@ -1986,10 +1986,12 @@ wsf_util_get_real_path(
 
 	if (VCWD_REALPATH(path, resolved_path_buff)) 
 	{
+#if PHP_VERSION_ID < 50399
 		if (PG(safe_mode) && (!php_checkuid(resolved_path_buff, NULL, CHECKUID_CHECK_FILE_AND_DIR))) 
 		{
 			return NULL;
 		}
+#endif
 
 		if (php_check_open_basedir(resolved_path_buff TSRMLS_CC)) 
 		{


### PR DESCRIPTION
Tested with Ubuntu 12.04
Remember to compile it using gcc 4.4: './configure CC=gcc-4.4'
